### PR TITLE
Handle nan/none samples during compression

### DIFF
--- a/src/amisc/component.py
+++ b/src/amisc/component.py
@@ -1009,6 +1009,7 @@ class Component(BaseModel, Serializable):
                     num_evals_prev = self.model_evals.get(a)
                     num_evals_new = len(costs)
                     prev_avg = self.model_costs.get(a)
+                    costs = np.nan_to_num(costs, nan=prev_avg)
                     new_avg = (np.sum(costs) + prev_avg * num_evals_prev) / (num_evals_prev + num_evals_new)
                     self.model_evals[a] += num_evals_new
                     self.model_costs[a] = float(new_avg)
@@ -1096,6 +1097,8 @@ class Component(BaseModel, Serializable):
 
         # Handle prediction with empty active set (return nan)
         if len(index_set) == 0:
+            self.logger.warning(f"Component '{self.name}' has an empty active set. "
+                                f"Has the surrogate been trained yet? Returning NaNs...")
             for var in self.outputs:
                 outputs[var.name] = np.full(loop_shape, np.nan)
             return outputs

--- a/src/amisc/component.py
+++ b/src/amisc/component.py
@@ -1023,7 +1023,7 @@ class Component(BaseModel, Serializable):
                     if field not in output_dict:
                         self.logger.warning(f"Model return missing field '{field}' for output variable '{var}'. "
                                             f"This may indicate an error during model evaluation. Returning NaNs...")
-                        output_dict[field].setdefault(field, np.full((N,), np.nan))
+                        output_dict.setdefault(field, np.full((N,), np.nan))
             elif var.name not in output_dict:
                 self.logger.warning(f"Model return missing output variable '{var.name}'. This may indicate "
                                     f"an error during model evaluation. Returning NaNs...")


### PR DESCRIPTION
Fixes #44, #45

## Proposed Changes

  - When passing an array of field quantities to `Variable.compress`, any empty samples (None or nan) get skipped, allowing all other good samples to work as expected.
  - Compressing an empty field quantity will return `nan` latent coefficients.
  - Reconstructing a set of `nan` latent coefficients will return an empty field quantity.
  - Typo fixed in call_model return value for missing outputs.
